### PR TITLE
Add impl std::error::Error for dynfmt::Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ lazy_static = { version = "1.2.0", optional = true }
 regex = { version = "1.1.0", optional = true }
 serde = "1.0.84"
 serde_json = { version = "1.0.36", optional = true }
+derive-enum-error = "0.0.1"
 
 [features]
 default = ["json"]

--- a/tests/test_error_messages.rs
+++ b/tests/test_error_messages.rs
@@ -1,0 +1,79 @@
+use std::borrow::Cow;
+
+use dynfmt::{Error, FormatType, Position};
+
+macro_rules! test_fmt {
+    ($name:ident, $expected:expr, $error:expr) => {
+        #[test]
+        fn $name() {
+            assert_eq!($expected, format!("{}", $error));
+        }
+    };
+}
+
+test_fmt!(bad_format, "unsupported format 'x'", Error::BadFormat('x'));
+test_fmt!(
+    parse,
+    "error parsing format string: x",
+    Error::Parse(Cow::Borrowed("x"))
+);
+test_fmt!(
+    list_required,
+    "format requires an argument list",
+    Error::ListRequired
+);
+test_fmt!(
+    map_required,
+    "format requires an argument map",
+    Error::MapRequired
+);
+test_fmt!(
+    missing_arg_key,
+    "missing argument: x",
+    Error::MissingArg(Position::Key("x"))
+);
+test_fmt!(
+    missing_arg_auto,
+    "missing argument: {next}",
+    Error::MissingArg(Position::Auto)
+);
+test_fmt!(
+    missing_arg_index,
+    "missing argument: 42",
+    Error::MissingArg(Position::Index(42))
+);
+test_fmt!(
+    bad_arg_key,
+    "argument 'x' cannot be formatted as object",
+    Error::BadArg(Position::Key("x"), FormatType::Object)
+);
+test_fmt!(
+    bad_arg_auto,
+    "argument '{next}' cannot be formatted as object",
+    Error::BadArg(Position::Auto, FormatType::Object)
+);
+test_fmt!(
+    bad_arg_index,
+    "argument '42' cannot be formatted as object",
+    Error::BadArg(Position::Index(42), FormatType::Object)
+);
+test_fmt!(
+    bad_data_key,
+    "error formatting argument 'x': %x",
+    Error::BadData(Position::Key("x"), "%x".into())
+);
+test_fmt!(
+    bad_data_auto,
+    "error formatting argument '{next}': %x",
+    Error::BadData(Position::Auto, "%x".into())
+);
+test_fmt!(
+    bad_data_index,
+    "error formatting argument '42': %x",
+    Error::BadData(Position::Index(42), "%x".into())
+);
+test_fmt!(
+    io_error,
+    "oops",
+    Error::Io(std::io::Error::new(std::io::ErrorKind::Other, "oops"))
+);


### PR DESCRIPTION
- Adds `derive-enum-error` as a dependency
  - Implements `std::error::Error` for `dynfmt::Error`
  - Also eliminates the need for a manual `fmt::Display` impl

Necessary for a project that I'm working on, which needs to be able to handle this library's error type as an error type.

**Warning**: The error messages are not exactly as they were! Check the test file I have written. For all the errors that involve Position there are differences.