### PR TITLE
Use maintained error lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.5
+
+- Update error derivation approach to use [thiserror](https://crates.io/crates/thiserror).
+
 ## 0.1.4
 
 - Fix a panic in the Python parser. When a pipe (`|`) occurred in the format string, the formatter would panic with `"unknown conversion flag"` due to an invalid Regex.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ lazy_static = { version = "1.2.0", optional = true }
 regex = { version = "1.1.0", optional = true }
 serde = "1.0.84"
 serde_json = { version = "1.0.36", optional = true }
-derive-enum-error = "0.0.1"
+thiserror = "1.0"
 
 [features]
 default = ["json"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dynfmt"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Jan Michael Auer <mail@jauer.org>"]
 edition = "2018"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,7 @@ pub enum Error<'a> {
 
     /// An I/O error occurred when writing into the target.
     #[error("{0}")]
-    Io(#[from] io::Error),
+    Io(#[source] io::Error),
 }
 
 impl<'a> Error<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ use std::borrow::Cow;
 use std::fmt;
 use std::io;
 
-use derive_enum_error::Error;
+use thiserror::Error;
 use erased_serde::Serialize as Serializable;
 use serde::ser::Serialize;
 
@@ -150,37 +150,37 @@ impl fmt::Display for Position<'_> {
 #[derive(Debug, Error)]
 pub enum Error<'a> {
     /// An unknown format character has been specified in the format.
-    #[error(display = "unsupported format '{}'", _0)]
+    #[error("unsupported format '{0}'")]
     BadFormat(char),
 
     /// A custom error during parsing a specific format.
-    #[error(display = "error parsing format string: {}", _0)]
+    #[error("error parsing format string: {0}")]
     Parse(Cow<'a, str>),
 
     /// The format refers to an indexed argument, but the argument list does not support indexed
     /// access.
-    #[error(display = "format requires an argument list")]
+    #[error("format requires an argument list")]
     ListRequired,
 
     /// The format refers to a named argument, but the argument list does not support named access.
-    #[error(display = "format requires an argument map")]
+    #[error("format requires an argument map")]
     MapRequired,
 
     /// An argument was missing from the argument list.
-    #[error(display = "missing argument: {}", _0)]
+    #[error("missing argument: {0}")]
     MissingArg(Position<'a>),
 
     /// An argument could not be formatted in the requested format.
-    #[error(display = "argument '{}' cannot be formatted as {}", _0, _1)]
+    #[error("argument '{0}' cannot be formatted as {1}")]
     BadArg(Position<'a>, FormatType),
 
     /// Formatting the data with the requested format resulted in an error.
-    #[error(display = "error formatting argument '{}': {}", _0, _1)]
+    #[error("error formatting argument '{0}': {1}")]
     BadData(Position<'a>, String),
 
     /// An I/O error occurred when writing into the target.
-    #[error(display = "{}", _0)]
-    Io(#[error(source)] io::Error),
+    #[error("{0}")]
+    Io(#[from] io::Error),
 }
 
 impl<'a> Error<'a> {


### PR DESCRIPTION
Hello, @jan-auer , thanks for the useful library!

When doing an update-and-deduplicate dependencies pass on one of my projects, I noticed that `dynfmt` was pulling in the pre-1.x versions of the `proc-macro2`/`syn` ecosystem through its use of the `derive-enum-error` crate.  I would have updated `derive-enum-error` and just submitted a PR to bump the version, but it seems that crate's repository is not available for public contribution.

Thus, this PR takes the easy way out of switching error-derivation to use one of the more mainstream error-derivation libraries, [thiserror](https://crates.io/crates/thiserror), which seems to be actively developed, open source, and uses more recent proc-macro dependencies.

AFAICT, the content and behavior of the public-facing error type have not changed in this PR.