### PR TITLE
Support pad zeros and width in Python formatter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ regex = { version = "1.1.0", optional = true }
 serde = "1.0.84"
 serde_json = { version = "1.0.36", optional = true }
 thiserror = "1.0"
+voca_rs = "1.13"
 
 [features]
 default = ["json"]

--- a/tests/test_python.rs
+++ b/tests/test_python.rs
@@ -20,6 +20,70 @@ macro_rules! test_fmt {
 
 test_fmt!(string_display, "hello, world!", "hello, %s!", "world");
 test_fmt!(number_display, "hello, 42!", "hello, %s!", 42);
+test_fmt!(string_width_display, "show:   Yo!", "show:%5s!", "Yo");
+test_fmt!(string_pad_zero_display, "show:   Yo!", "show:%05s!", "Yo");
+test_fmt!(char_width_display, "show:   Yo!", "show:%4so!", 'Y');
+test_fmt!(char_pad_zero_display, "show:   Yo!", "show:%04co!", 'Y');
+test_fmt!(
+    number_pad_zero_display_i8,
+    "show:00042!",
+    "show:%05d!",
+    42i8
+);
+test_fmt!(
+    number_pad_zero_display_i16,
+    "show:00042!",
+    "show:%05d!",
+    42i16
+);
+test_fmt!(
+    number_pad_zero_display_i32,
+    "show:00042!",
+    "show:%05d!",
+    42i32
+);
+test_fmt!(
+    number_pad_zero_display_i64,
+    "show:00042!",
+    "show:%05d!",
+    42i32
+);
+test_fmt!(
+    number_pad_zero_display_u8,
+    "show:00042!",
+    "show:%05d!",
+    42u8
+);
+test_fmt!(
+    number_pad_zero_display_u16,
+    "show:00042!",
+    "show:%05d!",
+    42u16
+);
+test_fmt!(
+    number_pad_zero_display_u32,
+    "show:00042!",
+    "show:%05d!",
+    42u32
+);
+test_fmt!(
+    number_pad_zero_display_u64,
+    "show:00042!",
+    "show:%05d!",
+    42u64
+);
+test_fmt!(
+    number_pad_zero_display_f32,
+    "show:00042!",
+    "show:%05d!",
+    42f32
+);
+test_fmt!(
+    number_pad_zero_display_f64,
+    "show:00042!",
+    "show:%05d!",
+    42f64
+);
 test_fmt!(negative_display, "hello, -42!", "hello, %s!", -42);
 test_fmt!(float_display, "hello, 4.2!", "hello, %s!", 4.2);
 test_fmt!(boolean_display, "hello, true!", "hello, %s!", true);


### PR DESCRIPTION
I've noticed that the Python formatter does didn't support padding and I would like to use this library in [a new GStreamer ](https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/merge_requests/514) plugin I'm working on to format segments file names. I took some time to implement this feature, I hope it looks good. But I'm open to make any necessary fixes to get this in. This library looks great and fill a gap in the Rust ecosystem, thank you for working on this and making it open source.

Please let me know what you think. 😃 