### PR TITLE
2021 edition; bump dependencies and clippy::swap_ptr_to_ref

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dynfmt"
 version = "0.1.5"
 authors = ["Jan Michael Auer <mail@jauer.org>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/jan-auer/dynfmt"
@@ -16,11 +16,11 @@ A crate for formatting strings dynamically.
 all-features = true
 
 [dependencies]
-erased-serde = "0.3.6"
-lazy_static = { version = "1.2.0", optional = true }
-regex = { version = "1.1.0", optional = true }
-serde = "1.0.84"
-serde_json = { version = "1.0.36", optional = true }
+erased-serde = "0.4"
+lazy_static = { version = "1.4", optional = true }
+regex = { version = "1", optional = true }
+serde = "1"
+serde_json = { version = "1", optional = true }
 thiserror = "1.0"
 
 [features]

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -142,7 +142,7 @@ where
     {
         unsafe {
             let mut placeholder = MaybeUninit::uninit();
-            mem::swap(self, &mut *placeholder.as_mut_ptr());
+            core::ptr::swap(self, placeholder.as_mut_ptr());
             let converted = f(placeholder.assume_init().into_inner());
             mem::forget(mem::replace(self, converted));
         }


### PR DESCRIPTION
In my qsv project, dynfmt using the SimpleCurlyFormat was working correctly in debug mode, but not in release mode!

Out of desperation, I tried modernizing dynfmt by just going to 2021 edition, bumping dependencies, and applying the clippy::swap_ptr_to_ref suggestion and it worked!

As to why, I dunno, but I'm contributing this back just in case other folks have a similar problem.